### PR TITLE
sendMessage() fails if OPFS is not available

### DIFF
--- a/src/chat/MessageInput.tsx
+++ b/src/chat/MessageInput.tsx
@@ -31,6 +31,9 @@ export function LazyImage(props: { name?: string, url?: string }) {
                     }
                 }
             })
+            .catch((error) => {
+                console.error("Error getting OPFS directory: %o", error);
+            });
     }, [name, url]);
 
     if (!url) {
@@ -202,14 +205,16 @@ export function MessageInput() {
                             console.log('Processing dropped image file: %o', file);
                             const reader = new FileReader();
                             reader.onload = async (e) => {
-                                const opfs = await navigator.storage.getDirectory();
-                                const fileHandle = await opfs.getFileHandle(file.name, { create: true });
-                                const writable = await fileHandle.createWritable();
-                                await writable.write(e.target?.result);
-                                await writable.close();
-                                console.log('File written to OPFS: %o', fileHandle);
-
-
+                                try {
+                                    const opfs = await navigator.storage.getDirectory();
+                                    const fileHandle = await opfs.getFileHandle(file.name, { create: true });
+                                    const writable = await fileHandle.createWritable();
+                                    await writable.write(e.target?.result);
+                                    await writable.close();
+                                    console.log('File written to OPFS: %o', fileHandle);
+                                } catch (error) {
+                                    console.error("Error writing file to OPFS: %o", error);
+                                }
                                 typeingMessage.images.push({ name: file.name, size: file.size, lastModified: file.lastModified, type: file.type });
                                 setState({ typeingMessage });
                             }

--- a/src/chat/context/action.ts
+++ b/src/chat/context/action.ts
@@ -31,7 +31,14 @@ export default function action(state: Partial<GlobalState>, dispatch: React.Disp
   const sendMessage = async () => {
     const { typeingMessage, options, chat, is, currentChat, user } = state;
 
-    const opfs = await navigator.storage.getDirectory();
+    let opfs = null;
+    
+    try { 
+      opfs = await navigator.storage.getDirectory();
+    }
+    catch (error) {
+      console.error("Error getting OPFS directory: %o", error);
+    }
 
     if (typeingMessage?.content) {
       let newMessage = null;
@@ -47,8 +54,9 @@ export default function action(state: Partial<GlobalState>, dispatch: React.Disp
           if (image.url) {
             return { type: "input_image", image_url: image.url };
           }
-          else if (image.name) {
+          else if (image.name && opfs) {
             console.log("sendMessage: reading file: %o", image.name);
+          
             // get file from OPFS
             const fileHandle = await opfs.getFileHandle(image.name);
             const promise = new Promise(async (resolve, reject) => {

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -245,6 +245,9 @@ i18n
                     "image_generation": "Bildgenerierung",
                     "image_generation_call": "Bildgenerierung",
                     "image_generation_call_description": "Bei dieser Antwort wurde eine Bildgenerierung durchgeführt.",
+
+                    opfs_not_supported: "Origin Private File System (OPFS) wird von Ihrem Browser nicht unterstützt.",
+                    opfs_not_supported_desc: "OPFS wird von Ihrem Browser nicht unterstützt, Bilder können nicht gespeichert werden. Bitte aktualisieren Sie Ihren Browser, um diese Funktion zu nutzen.",
                 },
             },
         },


### PR DESCRIPTION
- Older browsers may not support OPFS. Make sure to handle this exception.
- fixes #67 