### PR TITLE
fix: Show user-friendly error for AI Hub 'Unknown parameter: model' issue

### DIFF
--- a/src/chat/context/action.ts
+++ b/src/chat/context/action.ts
@@ -56,6 +56,23 @@ export default function action(
     setState({ is: { ...is, ...arg } });
   };
 
+  const setOptions = ({ type, data }: OptionAction) => {
+    console.log("set options: ", type, data);
+    const options = { ...state.options };
+    if (type === OptionActionType.OPENAI) {
+      options[type] = { ...options[type], ...data };
+    } else if (type === OptionActionType.GENERAL) {
+      options[type] = { ...options[type], ...data };
+      if (data.language) {
+        i18next.changeLanguage(data.language);
+      }
+    } else if (type === OptionActionType.ACCOUNT) {
+      options[type] = { ...options[type], ...data };
+    }
+    console.log("set options: ", options);
+    setState({ options });
+  };
+
   const startChat = (chat: Chat[], currentChat: number) =>
     dispatch({
       type: GlobalActionType.START_CHAT,
@@ -103,7 +120,7 @@ export default function action(
         typeingMessage: {},
         is: { ...state.is, thinking: true, tool: null },
       });
-      createResponse({ ...state, chat: newChat, setState, setIs }, this);
+      createResponse({ ...state, chat: newChat, setState, setIs, setOptions }, this);
     }
   };
 
@@ -180,7 +197,7 @@ export default function action(
       const _chat: Chat[] = chatList;
       if (newApp.botStarts) {
         console.log("botStarts");
-        createResponse({ ...state, chat: _chat, setState, setIs }, this);
+        createResponse({ ...state, chat: _chat, setState, setIs, setOptions }, this);
       } else {
         console.debug("starting chat: %o", _chat);
         startChat(_chat, 0);
@@ -305,22 +322,7 @@ export default function action(
       });
     },
 
-    setOptions({ type, data }: OptionAction) {
-      console.log("set options: ", type, data);
-      const options = { ...state.options };
-      if (type === OptionActionType.OPENAI) {
-        options[type] = { ...options[type], ...data };
-      } else if (type === OptionActionType.GENERAL) {
-        options[type] = { ...options[type], ...data };
-        if (data.language) {
-          i18next.changeLanguage(data.language);
-        }
-      } else if (type === OptionActionType.ACCOUNT) {
-        options[type] = { ...options[type], ...data };
-      }
-      console.log("set options: ", options);
-      setState({ options });
-    },
+    setOptions,
 
     currentList() {
       return state.chat[state.currentChat];

--- a/src/chat/context/action.ts
+++ b/src/chat/context/action.ts
@@ -120,7 +120,7 @@ export default function action(
         typeingMessage: {},
         is: { ...state.is, thinking: true, tool: null },
       });
-      createResponse({ ...state, chat: newChat, setState, setIs, setOptions }, this);
+      void createResponse({ ...state, chat: newChat, setState, setIs, setOptions }, this);
     }
   };
 
@@ -197,7 +197,7 @@ export default function action(
       const _chat: Chat[] = chatList;
       if (newApp.botStarts) {
         console.log("botStarts");
-        createResponse({ ...state, chat: _chat, setState, setIs, setOptions }, this);
+        void createResponse({ ...state, chat: _chat, setState, setIs, setOptions }, this);
       } else {
         console.debug("starting chat: %o", _chat);
         startChat(_chat, 0);

--- a/src/chat/service/__tests__/openai.test.ts
+++ b/src/chat/service/__tests__/openai.test.ts
@@ -19,9 +19,9 @@ vi.mock("i18next", () => ({
       login_required_description: "Please log in to continue.",
     };
     if (params) {
-      return translations[key] || key;
+      return Object.prototype.hasOwnProperty.call(translations, key) ? translations[key] : key;
     }
-    return translations[key] || key;
+    return Object.prototype.hasOwnProperty.call(translations, key) ? translations[key] : key;
   },
 }));
 
@@ -58,7 +58,7 @@ describe("Incompatible endpoint error detection", () => {
   it("should identify 'Unknown parameter: model' error", () => {
     const isModelParameterError = (message: string | undefined) => {
       return (
-        message?.includes("Unknown parameter") && message?.includes("'model'")
+        message?.includes("Unknown parameter") && message.includes("'model'")
       );
     };
 
@@ -100,7 +100,7 @@ describe("Incompatible endpoint error detection", () => {
 describe("Incompatible endpoint error handling logic", () => {
   it("should trigger specific error for model parameter error with Chat Completions endpoint", () => {
     const shouldShowIncompatibleEndpointError = (
-      error: APIError | null,
+      error: any,
       baseUrl: string | undefined
     ) => {
       if (
@@ -108,7 +108,7 @@ describe("Incompatible endpoint error handling logic", () => {
         error.message?.includes("Unknown parameter") &&
         error.message?.includes("'model'")
       ) {
-        const normalizedBaseUrl = baseUrl || "";
+        const normalizedBaseUrl = baseUrl ?? "";
         const isChatCompletionsEndpoint = normalizedBaseUrl.includes("/chat/completions");
         const isLegacyProxy = normalizedBaseUrl.includes("openai.ki.fh-swf.de/api");
 
@@ -134,7 +134,7 @@ describe("Incompatible endpoint error handling logic", () => {
 
   it("should trigger for legacy proxy endpoint", () => {
     const shouldShowIncompatibleEndpointError = (
-      error: APIError | null,
+      error: any,
       baseUrl: string | undefined
     ) => {
       if (
@@ -142,7 +142,7 @@ describe("Incompatible endpoint error handling logic", () => {
         error.message?.includes("Unknown parameter") &&
         error.message?.includes("'model'")
       ) {
-        const normalizedBaseUrl = baseUrl || "";
+        const normalizedBaseUrl = baseUrl ?? "";
         const isChatCompletionsEndpoint = normalizedBaseUrl.includes("/chat/completions");
         const isLegacyProxy = normalizedBaseUrl.includes("openai.ki.fh-swf.de/api");
 
@@ -165,7 +165,7 @@ describe("Incompatible endpoint error handling logic", () => {
 
   it("should not trigger for non-400 errors", () => {
     const shouldShowIncompatibleEndpointError = (
-      error: APIError | null,
+      error: any,
       baseUrl: string | undefined
     ) => {
       if (
@@ -173,7 +173,7 @@ describe("Incompatible endpoint error handling logic", () => {
         error.message?.includes("Unknown parameter") &&
         error.message?.includes("'model'")
       ) {
-        const normalizedBaseUrl = baseUrl || "";
+        const normalizedBaseUrl = baseUrl ?? "";
         const isChatCompletionsEndpoint = normalizedBaseUrl.includes("/chat/completions");
         const isLegacyProxy = normalizedBaseUrl.includes("openai.ki.fh-swf.de/api");
 
@@ -196,7 +196,7 @@ describe("Incompatible endpoint error handling logic", () => {
 
   it("should not trigger for other 'Unknown parameter' errors", () => {
     const shouldShowIncompatibleEndpointError = (
-      error: APIError | null,
+      error: any,
       baseUrl: string | undefined
     ) => {
       if (
@@ -204,7 +204,7 @@ describe("Incompatible endpoint error handling logic", () => {
         error.message?.includes("Unknown parameter") &&
         error.message?.includes("'model'")
       ) {
-        const normalizedBaseUrl = baseUrl || "";
+        const normalizedBaseUrl = baseUrl ?? "";
         const isChatCompletionsEndpoint = normalizedBaseUrl.includes("/chat/completions");
         const isLegacyProxy = normalizedBaseUrl.includes("openai.ki.fh-swf.de/api");
 

--- a/src/chat/service/__tests__/openai.test.ts
+++ b/src/chat/service/__tests__/openai.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi } from "vitest";
+import { APIError } from "openai";
+
+// Mock the toaster
+vi.mock("../../../components/ui/toaster", () => ({
+  toaster: {
+    create: vi.fn(),
+  },
+}));
+
+// Mock i18next
+vi.mock("i18next", () => ({
+  t: (key: string, params?: Record<string, unknown>) => {
+    const translations: Record<string, string> = {
+      error_occurred: "Error occurred",
+      ai_hub_responses_api_not_supported:
+        "The Responses API requires a compatible endpoint. Your current Base URL appears to be configured for the Chat Completions API. Please check your Base URL setting or reset to the default OpenAI API endpoint.",
+      login_required: "Login required",
+      login_required_description: "Please log in to continue.",
+    };
+    if (params) {
+      return translations[key] || key;
+    }
+    return translations[key] || key;
+  },
+}));
+
+// Mock Sentry
+vi.mock("@sentry/react", () => ({
+  captureException: vi.fn(),
+}));
+
+// Since we can't easily test the createResponse function without significant mocking,
+// let's test the error detection logic directly
+describe("Incompatible endpoint error detection", () => {
+  it("should detect Chat Completions endpoint from baseUrl", () => {
+    const isChatCompletionsEndpoint = (baseUrl: string) => {
+      return baseUrl.includes("/chat/completions");
+    };
+
+    expect(isChatCompletionsEndpoint("https://openai.ki.fh-swf.de/api/v1/chat/completions")).toBe(true);
+    expect(isChatCompletionsEndpoint("https://api.openai.com/v1/chat/completions")).toBe(true);
+    expect(isChatCompletionsEndpoint("https://api.openai.com/v1")).toBe(false);
+    expect(isChatCompletionsEndpoint("")).toBe(false);
+  });
+
+  it("should detect legacy proxy from baseUrl", () => {
+    const isLegacyProxy = (baseUrl: string) => {
+      return baseUrl.includes("openai.ki.fh-swf.de/api");
+    };
+
+    expect(isLegacyProxy("https://openai.ki.fh-swf.de/api/v1/chat/completions")).toBe(true);
+    expect(isLegacyProxy("https://openai.ki.fh-swf.de/api")).toBe(true);
+    expect(isLegacyProxy("https://hub.ki.fh-swf.de/v1")).toBe(false);
+    expect(isLegacyProxy("https://api.openai.com/v1")).toBe(false);
+  });
+
+  it("should identify 'Unknown parameter: model' error", () => {
+    const isModelParameterError = (message: string | undefined) => {
+      return (
+        message?.includes("Unknown parameter") && message?.includes("'model'")
+      );
+    };
+
+    expect(
+      isModelParameterError("Ws: 400 Unknown parameter: 'model'.")
+    ).toBe(true);
+    expect(
+      isModelParameterError("Unknown parameter: 'model' is not supported")
+    ).toBe(true);
+    expect(isModelParameterError("Unknown parameter: 'temperature'")).toBe(
+      false
+    );
+    expect(isModelParameterError("Error: something else")).toBe(false);
+  });
+
+  it("should detect APIError with 400 status", () => {
+    const mockError = new APIError(
+      400,
+      { message: "Unknown parameter: 'model'." },
+      "Ws: 400 Unknown parameter: 'model'."
+    );
+
+    expect(mockError.status).toBe(400);
+    expect(mockError.message).toContain("Unknown parameter");
+  });
+
+  it("should handle error with missing message", () => {
+    const isModelParameterError = (message: string | undefined) => {
+      return (
+        message?.includes("Unknown parameter") && message?.includes("'model'")
+      );
+    };
+
+    expect(isModelParameterError(undefined)).toBe(false);
+  });
+});
+
+// Test the combined error detection logic
+describe("Incompatible endpoint error handling logic", () => {
+  it("should trigger specific error for model parameter error with Chat Completions endpoint", () => {
+    const shouldShowIncompatibleEndpointError = (
+      error: APIError | null,
+      baseUrl: string | undefined
+    ) => {
+      if (
+        error?.status === 400 &&
+        error.message?.includes("Unknown parameter") &&
+        error.message?.includes("'model'")
+      ) {
+        const normalizedBaseUrl = baseUrl || "";
+        const isChatCompletionsEndpoint = normalizedBaseUrl.includes("/chat/completions");
+        const isLegacyProxy = normalizedBaseUrl.includes("openai.ki.fh-swf.de/api");
+
+        if (isChatCompletionsEndpoint || isLegacyProxy) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    const chatCompletionsUrl = "https://openai.ki.fh-swf.de/api/v1/chat/completions";
+    const apiError = new APIError(
+      400,
+      { message: "Unknown parameter: 'model'." },
+      "Ws: 400 Unknown parameter: 'model'."
+    );
+
+    expect(shouldShowIncompatibleEndpointError(apiError, chatCompletionsUrl)).toBe(true);
+    expect(
+      shouldShowIncompatibleEndpointError(apiError, "https://api.openai.com/v1")
+    ).toBe(false);
+  });
+
+  it("should trigger for legacy proxy endpoint", () => {
+    const shouldShowIncompatibleEndpointError = (
+      error: APIError | null,
+      baseUrl: string | undefined
+    ) => {
+      if (
+        error?.status === 400 &&
+        error.message?.includes("Unknown parameter") &&
+        error.message?.includes("'model'")
+      ) {
+        const normalizedBaseUrl = baseUrl || "";
+        const isChatCompletionsEndpoint = normalizedBaseUrl.includes("/chat/completions");
+        const isLegacyProxy = normalizedBaseUrl.includes("openai.ki.fh-swf.de/api");
+
+        if (isChatCompletionsEndpoint || isLegacyProxy) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    const legacyProxyUrl = "https://openai.ki.fh-swf.de/api";
+    const apiError = new APIError(
+      400,
+      { message: "Unknown parameter: 'model'." },
+      "Ws: 400 Unknown parameter: 'model'."
+    );
+
+    expect(shouldShowIncompatibleEndpointError(apiError, legacyProxyUrl)).toBe(true);
+  });
+
+  it("should not trigger for non-400 errors", () => {
+    const shouldShowIncompatibleEndpointError = (
+      error: APIError | null,
+      baseUrl: string | undefined
+    ) => {
+      if (
+        error?.status === 400 &&
+        error.message?.includes("Unknown parameter") &&
+        error.message?.includes("'model'")
+      ) {
+        const normalizedBaseUrl = baseUrl || "";
+        const isChatCompletionsEndpoint = normalizedBaseUrl.includes("/chat/completions");
+        const isLegacyProxy = normalizedBaseUrl.includes("openai.ki.fh-swf.de/api");
+
+        if (isChatCompletionsEndpoint || isLegacyProxy) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    const chatCompletionsUrl = "https://openai.ki.fh-swf.de/api/v1/chat/completions";
+    const unauthorizedError = new APIError(
+      401,
+      { message: "Unauthorized" },
+      "401 Unauthorized"
+    );
+
+    expect(shouldShowIncompatibleEndpointError(unauthorizedError, chatCompletionsUrl)).toBe(false);
+  });
+
+  it("should not trigger for other 'Unknown parameter' errors", () => {
+    const shouldShowIncompatibleEndpointError = (
+      error: APIError | null,
+      baseUrl: string | undefined
+    ) => {
+      if (
+        error?.status === 400 &&
+        error.message?.includes("Unknown parameter") &&
+        error.message?.includes("'model'")
+      ) {
+        const normalizedBaseUrl = baseUrl || "";
+        const isChatCompletionsEndpoint = normalizedBaseUrl.includes("/chat/completions");
+        const isLegacyProxy = normalizedBaseUrl.includes("openai.ki.fh-swf.de/api");
+
+        if (isChatCompletionsEndpoint || isLegacyProxy) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    const chatCompletionsUrl = "https://openai.ki.fh-swf.de/api/v1/chat/completions";
+    const temperatureError = new APIError(
+      400,
+      { message: "Unknown parameter: 'temperature'." },
+      "400 Unknown parameter: 'temperature'."
+    );
+
+    expect(shouldShowIncompatibleEndpointError(temperatureError, chatCompletionsUrl)).toBe(false);
+  });
+});

--- a/src/chat/service/openai.ts
+++ b/src/chat/service/openai.ts
@@ -4,6 +4,7 @@ import {
   GlobalActions,
   GlobalState,
   Options,
+  OptionActionType,
 } from "../context/types";
 import OpenAI, { APIError } from "openai";
 
@@ -62,7 +63,7 @@ export async function createResponse(
   parent,
   explicitInput?: ResponseInput
 ) {
-  const { options, chat, currentChat, is, setState, setIs } = global;
+  const { options, chat, currentChat, is, setState, setIs, setOptions } = global;
   const client = createClient(options);
 
   console.log("messages: %o", chat[currentChat].messages);
@@ -238,8 +239,21 @@ export async function createResponse(
             title: t("ai_hub_not_supported_title") || t("error_occurred"),
             description: t("ai_hub_responses_api_not_supported") ||
               "The Responses API requires a compatible endpoint. Please check your Base URL setting or reset to the default OpenAI API endpoint.",
-            duration: 8000,
+            duration: 10000,
             type: "error",
+            action: {
+              label: t("reset_to_default") || "Reset to Default",
+              onClick: () => {
+                if (setOptions) {
+                  setOptions({
+                    type: OptionActionType.OPENAI,
+                    data: {
+                      baseUrl: apiBaseUrl,
+                    },
+                  });
+                }
+              },
+            },
           });
           return;
         }

--- a/src/chat/service/openai.ts
+++ b/src/chat/service/openai.ts
@@ -223,6 +223,27 @@ export async function createResponse(
         window.location.href = import.meta.env.VITE_LOGIN_URL;
         return;
       }
+
+      // Check for "Unknown parameter: 'model'" error when using incompatible endpoint
+      if (apiError.status === 400 &&
+          error.message?.includes("Unknown parameter") &&
+          error.message?.includes("'model'")) {
+        // Check if using a Chat Completions endpoint with Responses API
+        const baseUrl = options?.openai?.baseUrl || "";
+        const isChatCompletionsEndpoint = baseUrl.includes("/chat/completions");
+        const isLegacyProxy = baseUrl.includes("openai.ki.fh-swf.de/api");
+
+        if (isChatCompletionsEndpoint || isLegacyProxy) {
+          toaster.create({
+            title: t("ai_hub_not_supported_title") || t("error_occurred"),
+            description: t("ai_hub_responses_api_not_supported") ||
+              "The Responses API requires a compatible endpoint. Please check your Base URL setting or reset to the default OpenAI API endpoint.",
+            duration: 8000,
+            type: "error",
+          });
+          return;
+        }
+      }
     }
 
     toaster.create({

--- a/src/chat/service/openai.ts
+++ b/src/chat/service/openai.ts
@@ -230,7 +230,7 @@ export async function createResponse(
           error.message?.includes("Unknown parameter") &&
           error.message?.includes("'model'")) {
         // Check if using a Chat Completions endpoint with Responses API
-        const baseUrl = options?.openai?.baseUrl || "";
+        const baseUrl = options?.openai.baseUrl ?? "";
         const isChatCompletionsEndpoint = baseUrl.includes("/chat/completions");
         const isLegacyProxy = baseUrl.includes("openai.ki.fh-swf.de/api");
 

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -132,6 +132,8 @@ Access to the chat is only available to members of FH SWF. If you are a member, 
             "The AI-Hub response did not contain an API key.",
           ai_hub_model_list_failed_desc:
             "The AI-Hub models could not be loaded. Status: {{status}}.",
+          ai_hub_responses_api_not_supported:
+            "The Responses API requires a compatible endpoint. Your current Base URL appears to be configured for the Chat Completions API. Please check your Base URL setting or reset to the default OpenAI API endpoint.",
           chat_history: "Chat History",
           close: "Close",
           empty_chat: "Empty Chat",
@@ -337,6 +339,8 @@ Wenn du ein Mitglied bist, melde dich bitte mit Deiner **Hochschulkennung** an.
             "Die AI-Hub-Antwort enthielt keinen API-Schlüssel.",
           ai_hub_model_list_failed_desc:
             "Die AI-Hub-Modelle konnten nicht geladen werden. Status: {{status}}.",
+          ai_hub_responses_api_not_supported:
+            "Die Responses API erfordert einen kompatiblen Endpunkt. Ihre aktuelle Base-URL scheint für die Chat Completions API konfiguriert zu sein. Bitte überprüfen Sie Ihre Base-URL-Einstellung oder setzen Sie sie auf den Standard-OpenAI-API-Endpunkt zurück.",
 
           Title: "Titel",
           Cancel: "Abbrechen",

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -134,6 +134,7 @@ Access to the chat is only available to members of FH SWF. If you are a member, 
             "The AI-Hub models could not be loaded. Status: {{status}}.",
           ai_hub_responses_api_not_supported:
             "The Responses API requires a compatible endpoint. Your current Base URL appears to be configured for the Chat Completions API. Please check your Base URL setting or reset to the default OpenAI API endpoint.",
+          reset_to_default: "Reset to Default",
           chat_history: "Chat History",
           close: "Close",
           empty_chat: "Empty Chat",
@@ -341,6 +342,7 @@ Wenn du ein Mitglied bist, melde dich bitte mit Deiner **Hochschulkennung** an.
             "Die AI-Hub-Modelle konnten nicht geladen werden. Status: {{status}}.",
           ai_hub_responses_api_not_supported:
             "Die Responses API erfordert einen kompatiblen Endpunkt. Ihre aktuelle Base-URL scheint für die Chat Completions API konfiguriert zu sein. Bitte überprüfen Sie Ihre Base-URL-Einstellung oder setzen Sie sie auf den Standard-OpenAI-API-Endpunkt zurück.",
+          reset_to_default: "Auf Standard zurücksetzen",
 
           Title: "Titel",
           Cancel: "Abbrechen",


### PR DESCRIPTION
## Summary

When a user has configured a custom Base URL pointing to a Chat Completions API endpoint (e.g., `/v1/chat/completions`), the Responses API returns an "Unknown parameter: model" error. This happens because the application uses the Responses API (`client.responses.create()`), but the endpoint is configured for the Chat Completions API.

## Changes

- **Error Detection**: Added logic in `handleError()` to detect when the error is specifically about the "model" parameter with a 400 status code and the user has a Chat Completions endpoint configured
- **User-Friendly Message**: Shows a clear error message explaining that the Responses API requires a compatible endpoint
- **Action Button**: Added a "Reset to Default" button that resets the Base URL to the default OpenAI API endpoint directly from the error toast
- **Translations**: Added translation keys for both English and German

## Technical Details

The fix detects the specific error pattern:
- HTTP 400 status
- Error message contains "Unknown parameter"
- Error message contains "model"
- Base URL contains "/chat/completions" or "openai.ki.fh-swf.de/api" (Chat Completions or legacy proxy)

When all conditions are met, a user-friendly error message is displayed with a "Reset to Default" action button.

## Testing

- Added unit tests for the error detection logic in `src/chat/service/__tests__/openai.test.ts`

Fixes #127