### PR TITLE
fix: add 'auto' theme icon to resolve 'Icon auto not found' error

### DIFF
--- a/playwright/tests/authorized/ui_settings.spec.ts
+++ b/playwright/tests/authorized/ui_settings.spec.ts
@@ -125,6 +125,43 @@ test.describe("Dark Mode", () => {
     await page.getByTestId("themeSelectlight").click({ force: true });
     await expect(html).toHaveAttribute("data-theme", "light");
   });
+
+  test("Auto theme in Settings should not show console error", async ({ page }) => {
+    const configBtn = page.getByTestId("OpenConfigBtn");
+    await expect(configBtn).toBeVisible({ timeout: 10000 });
+    await configBtn.click();
+    const html = page.locator("html");
+
+    // Force light to start
+    await page.evaluate(() =>
+      document.documentElement.setAttribute("data-theme", "light")
+    );
+    await expect(html).toHaveAttribute("data-theme", "light");
+
+    // Collect console errors
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    // Select Auto in settings (Radio Group)
+    await page.getByTestId("themeSelectauto").click({ force: true });
+
+    // Wait a moment for any potential console errors to be logged
+    await page.waitForTimeout(500);
+
+    // Verify no "Icon auto not found" error is logged
+    const iconErrors = consoleErrors.filter((err) =>
+      err.includes("Icon auto not found")
+    );
+    expect(iconErrors).toHaveLength(0);
+
+    // Verify the theme button is visible (showing the auto icon)
+    const optionDarkModeSelect = page.getByTestId("OptionDarkModeSelect");
+    await expect(optionDarkModeSelect).toBeVisible({ timeout: 5000 });
+  });
 });
 
 test.describe("User Information", () => {

--- a/src/chat/ChatSideBar.tsx
+++ b/src/chat/ChatSideBar.tsx
@@ -27,6 +27,7 @@ import { MdOutlineDarkMode } from "react-icons/md";
 import { MdOutlineLightMode } from "react-icons/md";
 import { TbArrowsMinimize } from "react-icons/tb";
 import { TbArrowsMaximize } from "react-icons/tb";
+import { LuMonitor } from "react-icons/lu";
 import { useGlobal } from "./context";
 import { classnames } from "../components/utils";
 import { useOptions } from "./hooks";
@@ -48,6 +49,7 @@ const ICONS = {
   config: IoSettingsOutline,
   dark: MdOutlineDarkMode,
   light: MdOutlineLightMode,
+  auto: LuMonitor,
   "min-screen": TbArrowsMinimize,
   "full-screen": TbArrowsMaximize,
 };


### PR DESCRIPTION
## Summary

This PR fixes issue #134 where selecting the "Auto" theme would cause an error: "Error: Icon auto not found".

## Root Cause

The `themeOptions` in `options.ts` includes "Auto" as a valid theme option, but the `ICONS` map in `ChatSideBar.tsx` didn't have an icon defined for the "auto" value. When users selected "Auto" theme, the `Option` component tried to render an icon that didn't exist in the map, resulting in the console error.

## Changes

1. **src/chat/ChatSideBar.tsx**:
   - Added import for `LuMonitor` from `react-icons/lu`
   - Added `auto: LuMonitor` to the `ICONS` map

2. **playwright/tests/authorized/ui_settings.spec.ts**:
   - Added test case "Auto theme in Settings should not show console error" to verify the fix

## Testing

- Build completed successfully
- The test verifies that selecting "Auto" theme doesn't produce the "Icon auto not found" console error


@cgawron can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cb1bf8be-14d7-4b49-9fe5-0099c10f23a4)