### PR TITLE
fix: recognize multi-line \[...\] blocks as LaTeX

### DIFF
--- a/src/chat/utils/__tests__/latex.test.ts
+++ b/src/chat/utils/__tests__/latex.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { processLaTeX } from "../latex";
+
+describe("processLaTeX", () => {
+  it("should convert multi-line block LaTeX (\\[...\\]) to markdown-compatible $$ syntax", () => {
+    // Regression test for https://github.com/fhswf/openai-ui/issues/142
+    const input = `2023 ist **keine Primzahl**. Es lässt sich zerlegen:
+
+\\[
+2023 = 7 \\cdot 289 = 7 \\cdot 17^2
+\\]
+
+Da 2023 außer 1 und sich selbst noch die Teiler 7 und 17 besitzt, ist es eine **zusammengesetzte Zahl**.`;
+
+    const result = processLaTeX(input);
+
+    expect(result).toContain(
+      "$$\n2023 = 7 \\cdot 289 = 7 \\cdot 17^2\n$$"
+    );
+    expect(result).not.toContain("\\[");
+    expect(result).not.toContain("\\]");
+  });
+
+  it("should convert single-line block LaTeX (\\[...\\]) to $$ syntax", () => {
+    const input = "Ein Beispiel: \\[ x^2 + y^2 = z^2 \\] fertig.";
+    const result = processLaTeX(input);
+    expect(result).toBe("Ein Beispiel: $$ x^2 + y^2 = z^2 $$ fertig.");
+  });
+
+  it("should convert inline LaTeX (\\(...\\)) to $ syntax", () => {
+    const input = "Die Formel \\(a^2 + b^2 = c^2\\) ist bekannt.";
+    const result = processLaTeX(input);
+    expect(result).toBe("Die Formel $a^2 + b^2 = c^2$ ist bekannt.");
+  });
+
+  it("should detect multi-line \\begin{equation}...\\end{equation} blocks", () => {
+    const input =
+      "Text\n\\begin{equation}\nx = 1\n\\end{equation}\nmore text with \\(y=2\\)";
+    const result = processLaTeX(input);
+    expect(result).toContain("\\begin{equation}\nx = 1\n\\end{equation}");
+    expect(result).toContain("$y=2$");
+  });
+
+  it("should leave content without LaTeX unchanged", () => {
+    const input = "Einfacher Text **ohne** LaTeX.";
+    expect(processLaTeX(input)).toBe(input);
+  });
+
+  it("should not convert LaTeX inside code blocks", () => {
+    const input = "Code:\n```\n\\[\nnot = latex\n\\]\n```";
+    expect(processLaTeX(input)).toBe(input);
+  });
+
+  it("should escape dollar signs followed by digits", () => {
+    const input = "Das kostet $5 und $10.";
+    expect(processLaTeX(input)).toBe("Das kostet \\$5 und \\$10.");
+  });
+});

--- a/src/chat/utils/latex.ts
+++ b/src/chat/utils/latex.ts
@@ -1,6 +1,8 @@
 // Regex to check if the processed content contains any potential LaTeX patterns
+// Note: block-level delimiters (\[...\], \begin{equation}...\end{equation})
+// may span multiple lines, so they need to match newlines as well.
 const containsLatexRegex =
-  /\\\(.*?\\\)|\\\[.*?\\\]|\$.*?\$|\\begin\{equation\}.*?\\end\{equation\}/;
+  /\\\(.*?\\\)|\\\[[\s\S]*?\\\]|\$.*?\$|\\begin\{equation\}[\s\S]*?\\end\{equation\}/;
 
 // Regex for inline and block LaTeX expressions
 const inlineLatex = new RegExp(/\\\((.+?)\\\)/, "g");


### PR DESCRIPTION
## Problem

As reported in #142, LLM output containing multi-line block LaTeX such as

```
\[
2023 = 7 \cdot 289 = 7 \cdot 17^2
\]
```

was rendered as plain text instead of a LaTeX formula.

## Root cause

In `src/chat/utils/latex.ts`, the `containsLatexRegex` guard used `.` for the block-level delimiters (`\[...\]` and `\begin{equation}...\end{equation}`). Since `.` does not match newlines, multi-line block formulas were never detected, `processLaTeX` returned the content unchanged, and the (already multi-line-capable) `blockLatex` replacement never ran.

## Fix

Use `[\s\S]` instead of `.` for the block-level patterns in `containsLatexRegex`, so multi-line `\[...\]` and `\begin{equation}...\end{equation}` blocks are detected and converted to `$$...$$`. Inline patterns (`\(...\)`, `$...$`) are intentionally unchanged, matching the single-line replacement regexes.

## Tests

Added `src/chat/utils/__tests__/latex.test.ts` with 7 unit tests for `processLaTeX`, including a regression test using the exact multi-line block formula from the issue. Verified:

- The regression test **fails** on the unfixed code and **passes** with the fix.
- All 7 new tests pass (`npx vitest run src/chat/utils/__tests__/latex.test.ts`).
- The one failing test in the full suite (`isModelParameterError` in `openai.test.ts`) pre-exists on the base branch and is unrelated to this change.

Fixes #142

---
*This PR was created by an AI agent (OpenHands) on behalf of the issue reporter.*

@cgawron can click here to [continue refining the PR](https://app.all-hands.dev/conversations/47c70e22-c32c-4385-9fe5-81b20eebc169)