### PR TITLE
Fix cluttered model list by grouping and sorting models by provider

### DIFF
--- a/src/chat/ChatOptions.tsx
+++ b/src/chat/ChatOptions.tsx
@@ -8,6 +8,7 @@ import {
   languageOptions,
   sendCommandOptions,
   getModelOptions,
+  groupModelOptions,
 } from "./utils/options";
 import {
   Button,
@@ -21,6 +22,7 @@ import {
 } from "@chakra-ui/react";
 
 import { Select } from "@chakra-ui/react";
+import { SelectItemGroup } from "../components/ui/select";
 import { FileUpload } from "@chakra-ui/react";
 import { Slider } from "@chakra-ui/react";
 
@@ -253,11 +255,27 @@ export function ChatOptions() {
                 <Select.ValueText placeholder={openai.model} />
               </Select.Trigger>
               <Select.Content>
-                {availableModelOptions.map((model) => (
-                  <Select.Item item={model} key={model.value}>
-                    {model.label}
-                  </Select.Item>
-                ))}
+                {(() => {
+                  const groups = groupModelOptions(availableModelOptions);
+                  if (groups.length === 0) {
+                    return availableModelOptions.map((model) => (
+                      <Select.Item item={model} key={model.value}>
+                        {model.label}
+                        <Select.ItemIndicator />
+                      </Select.Item>
+                    ));
+                  }
+                  return groups.map(([group, items]) => (
+                    <SelectItemGroup key={group} label={group}>
+                      {items.map((model) => (
+                        <Select.Item item={model} key={model.value}>
+                          {model.label}
+                          <Select.ItemIndicator />
+                        </Select.Item>
+                      ))}
+                    </SelectItemGroup>
+                  ));
+                })()}
               </Select.Content>
             </Select.Root>
             <Field.HelperText>{t("openai_model_help")}</Field.HelperText>

--- a/src/chat/MessageHeader.tsx
+++ b/src/chat/MessageHeader.tsx
@@ -50,7 +50,7 @@ import { useMessage } from "./hooks";
 import { classnames } from "../components/utils";
 import styles from "./style/menu.module.less";
 import { MessageMenu } from "./MessageMenu";
-import { getModelOptions } from "./utils/options";
+import { getModelOptions, groupModelOptions } from "./utils/options";
 import { GitHubMenu } from "./GitHubMenu";
 import { UsageInformationDialog } from "./UsageInformationDialog";
 import { McpAuthFields } from "./McpAuthFields";
@@ -149,25 +149,47 @@ interface ModelOptionsGroupProps {
 function ModelOptionsGroup({ openai, setOptions }: ModelOptionsGroupProps) {
   const { t } = useTranslation();
   const options = getModelOptions(openai);
+  const groups = groupModelOptions(options);
+
+  const setModel = (value: string) => {
+    setOptions({
+      type: OptionActionType.OPENAI,
+      data: { ...openai, model: value },
+    });
+  };
+
+  if (groups.length <= 1) {
+    return (
+      <Menu.RadioItemGroup value={openai.model} onValueChange={(event) => { setModel(event.value); }}>
+        <Menu.ItemGroupLabel>{t("model_options")}</Menu.ItemGroupLabel>
+        {options.map((item) => (
+          <Menu.RadioItem key={item.value} value={item.value}>
+            {item.label}
+            <Menu.ItemIndicator />
+          </Menu.RadioItem>
+        ))}
+      </Menu.RadioItemGroup>
+    );
+  }
 
   return (
-    <Menu.RadioItemGroup
-      value={openai.model}
-      onValueChange={(event) => {
-        setOptions({
-          type: OptionActionType.OPENAI,
-          data: { ...openai, model: event.value },
-        });
-      }}
-    >
-      <Menu.ItemGroupLabel>{t("model_options")}</Menu.ItemGroupLabel>
-      {options.map((item) => (
-        <Menu.RadioItem key={item.value} value={item.value}>
-          {item.label}
-          <Menu.ItemIndicator />
-        </Menu.RadioItem>
+    <>
+      {groups.map(([group, items]) => (
+        <Menu.RadioItemGroup
+          key={group}
+          value={openai.model}
+          onValueChange={(event) => { setModel(event.value); }}
+        >
+          <Menu.ItemGroupLabel>{group}</Menu.ItemGroupLabel>
+          {items.map((item) => (
+            <Menu.RadioItem key={item.value} value={item.value}>
+              {item.label}
+              <Menu.ItemIndicator />
+            </Menu.RadioItem>
+          ))}
+        </Menu.RadioItemGroup>
       ))}
-    </Menu.RadioItemGroup>
+    </>
   );
 }
 

--- a/src/chat/utils/__tests__/options.test.ts
+++ b/src/chat/utils/__tests__/options.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { modelOptions } from "../options";
+import { getModelOptions, modelOptions } from "../options";
 
 describe("modelOptions", () => {
   it("should include gpt-5.6-luna model", () => {
@@ -34,5 +34,55 @@ describe("modelOptions", () => {
     });
 
     expect(modelOptions.length).toBe(expectedModels.length);
+  });
+});
+
+describe("getModelOptions", () => {
+  it("should sort recommended models by generation when no AI Hub models are configured", () => {
+    const options = getModelOptions();
+    expect(options.map((opt) => opt.value)).toEqual([
+      "gpt-5.6-luna",
+      "gpt-5.4-mini",
+      "gpt-5.4-nano",
+      "gpt-5-mini",
+      "gpt-5-nano",
+      "gpt-4.1-mini",
+      "gpt-4.1-nano",
+      "gpt-4-turbo",
+      "gpt-4o-mini",
+      "gpt-4",
+      "gpt-3.5-turbo",
+    ]);
+    expect(options.every((opt) => opt.group === undefined)).toBe(true);
+  });
+
+  it("should append and sort AI Hub models in the combined list", () => {
+    const options = getModelOptions({
+      aiHubModels: ["gpt-4.1-mini", "anthropic/claude-3.5-sonnet", "google/gemini-2.0-flash"],
+    });
+    const values = options.map((opt) => opt.value);
+    // recommended OpenAI models first, then the provider-prefixed models installed their generation order
+    expect(values.indexOf("anthropic/claude-3.5-sonnet")).toBeLessThan(values.indexOf("google/gemini-2.0-flash"));
+    expect(values.filter((value) => value === "gpt-4.1-mini")).toHaveLength(1);
+  });
+
+  it("should tag group name when multiple providers are present", () => {
+    const options = getModelOptions({
+      aiHubModels: ["anthropic/claude-3.5-sonnet", "google/gemini-2.0-flash"],
+    });
+    const groups = options.map((opt) => opt.group);
+    expect(groups).toContain("OpenAI");
+    expect(groups).toContain("Anthropic");
+    expect(groups).toContain("Google");
+    // models from the same provider stay adjacent
+    expect(options.filter((opt) => opt.group === "Google").length).toBe(1);
+    expect(options.filter((opt) => opt.group === "Anthropic").length).toBe(1);
+  });
+
+  it("should not tag group name when only one provider is present", () => {
+    const options = getModelOptions({
+      aiHubModels: ["openai/gpt-4.1-mini"],
+    });
+    expect(options.every((opt) => opt.group === undefined)).toBe(true);
   });
 });

--- a/src/chat/utils/options.ts
+++ b/src/chat/utils/options.ts
@@ -77,22 +77,128 @@ export const modelOptions = [
   },
 ];
 
-export function getModelOptions(openai?: Pick<OpenAIOptions, "aiHubModels" | "model">) {
-  const items = [...modelOptions];
-  const seen = new Set(items.map((item) => item.value));
+export interface ModelOption {
+  label: string;
+  value: string;
+  group?: string;
+}
 
-  openai?.aiHubModels?.forEach((model) => {
-    if (!seen.has(model)) {
-      items.push({ label: model, value: model });
-      seen.add(model);
+const PROVIDER_PATTERNS: readonly { group: string; pattern: RegExp }[] = [
+  { group: "Anthropic", pattern: /^(?:anthropic|claude)[/:-]/i },
+  { group: "OpenAI", pattern: /^(?:openai|gpt-|o[0-9])[/:.-]/i },
+  { group: "Google", pattern: /^(?:google|gemini)[/:-]/i },
+];
+
+const GENERATION_RANK: Map<string, number> = new Map([
+  ["5.6", 0],
+  ["5.4", 1],
+  ["5",  2],
+  ["4.1",  3],
+  ["4",  4],
+  ["3.5",  5],
+]);
+
+const PROVIDER_ORDER: Map<string, number> = new Map([
+  ["OpenAI",  0],
+  ["Anthropic",  1],
+  ["Google",  2],
+]);
+
+function providerGroupOf(model: string): string {
+  for (const entry of PROVIDER_PATTERNS) {
+    if (entry.pattern.test(model)) {
+      return entry.group;
     }
-  });
-
-  if (openai?.model && !seen.has(openai.model)) {
-    items.push({ label: openai.model, value: openai.model });
   }
+  if (model.toLowerCase().startsWith("gpt-")) {
+    return "OpenAI";
+  }
+  const fallback = model.split(/[/:.]/)[0];
+  return fallback ? fallback[0].toUpperCase() + fallback.slice(1) : "";
+}
 
-  return items;
+function gptGenerationOf(model: string): string {
+  const value = model.toLowerCase();
+  const generation = /(5\.6|5\.4|5|4\.1|4|3\.5)/.exec(value)?.[1];
+  return generation && GENERATION_RANK.has(generation) ? generation : "";
+}
+
+function modelSortKey(model: string): string {
+  const provider = providerGroupOf(model);
+  const providerRank = (PROVIDER_ORDER.get(provider) ?? 99).toString().padStart(2, "0");
+  const gptGeneration = gptGenerationOf(model);
+  if (!gptGeneration) {
+    return providerRank + "::" + model;
+  }
+  const generationRank = (GENERATION_RANK.get(gptGeneration) ?? 99).toString().padStart(2, "0");
+  return providerRank + "::" + generationRank + "::" + modelTiebreakKey(model);
+}
+
+function modelTiebreakKey(model: string): string {
+  const value = model.toLowerCase();
+  if (value.includes("luna")) return "0";
+  if (value.includes("turbo")) return "1";
+  if (value.includes("o-mini") || value.includes("o-nano")) return "2";
+  if (value.includes("mini")) return "3";
+  if (value.includes("nano")) return "4";
+  return "5";
+}
+
+function groupModelsByIds(ids: string[]): ModelOption[] {
+  const sorted = [...ids];
+  sorted.sort((left, right) => {
+    const leftKey = modelSortKey(left);
+    const rightKey = modelSortKey(right);
+    return leftKey.localeCompare(rightKey);
+  });
+  return sorted.map((entry) => ({ label: entry, value: entry }));
+}
+
+export function groupModelOptions(options: ModelOption[]): [string, ModelOption[]][] {
+  const groups = new Map<string, ModelOption[]>();
+  for (const option of options) {
+    const group = option.group ?? "";
+    const items = groups.get(group) ?? [];
+    items.push(option);
+    groups.set(group, items);
+  }
+  return [...groups.entries()];
+}
+
+function withGroupInfo(options: ModelOption[]): ModelOption[] {
+  return options.map((option) => ({
+    ...option,
+    group: providerGroupOf(option.value),
+  }));
+}
+export function getModelOptions(openai?: Pick<OpenAIOptions, "aiHubModels" | "model">): ModelOption[] {
+  const seen = new Set<string>();
+  const recommended: string[] = [];
+  for (const model of modelOptions.map((option) => option.value)) {
+    if (!seen.has(model)) {
+      seen.add(model);
+      recommended.push(model);
+    }
+  }
+  const aiHub: string[] = [];
+  for (const model of openai?.aiHubModels ?? []) {
+    if (!seen.has(model)) {
+      seen.add(model);
+      aiHub.push(model);
+    }
+  }
+  const extra: string[] = [];
+  if (openai?.model && !seen.has(openai.model)) {
+    seen.add(openai.model);
+    extra.push(openai.model);
+  }
+  const allModels = [...recommended, ...aiHub, ...extra];
+  const sorted = groupModelsByIds(allModels);
+  const showProviders = new Set(allModels.map(providerGroupOf)).size > 1;
+  if (showProviders) {
+    return withGroupInfo(sorted);
+  }
+  return sorted;
 }
 
 export const toolOptions: Map<string, Tool> = new Map([


### PR DESCRIPTION
## Summary

Closes #152 — the model list in the **AI Hub Budget** (LiteLLM proxy) selector is long and cluttered. This change makes it readable by:

- **Sorting** models in a deterministic order: provider group first (OpenAI -> Anthropic -> Google -> others), then GPT generation (newest-first: 5.6 ->  ɨ5.4 ->  ɨ5 ->  ɨ4.1 ->  ɨ4 ->  ɨ3.5)。
- **Grouping** the model list into provider sections: when multiple providers are configured, models render grouped headers (e.g. OpenAI, Anthropic, Google); when only one provider is present, headings are suppressed and the list stays compact.
.
。- **Deduplication**: AI Hub models that duplicate the recommended built-in list are no longer repeated。



## Changes

- `src/chat/utils/options.ts`: reworked `getModelOptions()` — added `ModelOption.group`, provider-detection (`providerGroupOf`), generation detection/rank tables,, sort key (`modelSortKey`), `groupModelOptions()` helper; results now sorted/grouped/dedupedharm
- `src/chat/ChatOptions.tsx`: model `Select` renders grouped `<SelectItemGroup>` sections with provider headings
- `src/chat/MessageHeader.tsx`: model `Menu` renders grouped `<Menu.RadioItemGroup>` sections per provider
- `src/chat/utils/__tests__/options.test.ts`: added tests covering sorting-by-generation, append/sort AI Hub models, provider-group tagging (multi-provider), no-tagging single-provider



## Test Plan

- `npx vitest run src/chat/utils/__tests__/options.test.ts` — all 7 tests pass
- Full unit suite: 22/23 pass — the 1 failure (`openai.test.ts`) is a **pre-existing** failure on `main` (verified via stash; unchanged by this PR)。

This PR was created by an AI agent (OpenHands) on behalf of the repository maintainers。

